### PR TITLE
Dillon/food restriction on rsvp

### DIFF
--- a/src/main/java/com/dillon/weddingrsvpapi/controller/RsvpController.java
+++ b/src/main/java/com/dillon/weddingrsvpapi/controller/RsvpController.java
@@ -46,7 +46,7 @@ public class RsvpController {
      */
     @PostMapping("/update-rsvps")
     public void updateRsvp(@RequestBody List<@Valid Rsvp> rsvps) {
-        rsvpService.updateRsvpsAttending(rsvps);
+        rsvpService.updateRsvpAttendingAndFoodRestrictions(rsvps);
     }
 }
 

--- a/src/main/java/com/dillon/weddingrsvpapi/controller/RsvpGroupController.java
+++ b/src/main/java/com/dillon/weddingrsvpapi/controller/RsvpGroupController.java
@@ -1,10 +1,14 @@
 package com.dillon.weddingrsvpapi.controller;
 
+import com.dillon.weddingrsvpapi.dto.Rsvp;
 import com.dillon.weddingrsvpapi.dto.RsvpGroup;
 import com.dillon.weddingrsvpapi.service.RsvpGroupService;
+import com.dillon.weddingrsvpapi.service.RsvpService;
 import jakarta.validation.Valid;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -20,12 +24,18 @@ public class RsvpGroupController {
     private final RsvpGroupService rsvpGroupService;
 
     /**
+     * Rsvp service bean.
+     */
+    private final RsvpService rsvpService;
+
+    /**
      * Constructor for the RsvpGroupController class.
      *
      * @param rsvpGroupService RsvpGroupService bean.
      */
-    public RsvpGroupController(RsvpGroupService rsvpGroupService) {
+    public RsvpGroupController(RsvpGroupService rsvpGroupService, RsvpService rsvpService) {
         this.rsvpGroupService = rsvpGroupService;
+        this.rsvpService = rsvpService;
     }
 
     /**
@@ -56,7 +66,23 @@ public class RsvpGroupController {
      * @param rsvpGroups List of JSON objects that represents rsvp groups.
      */
     @PostMapping("/update-rsvp-groups")
-    public void updateRsvpGroups(@RequestBody List<@Valid RsvpGroup> rsvpGroups) {
-        rsvpGroupService.updateRsvpGroups(rsvpGroups);
+    public void updateRsvpGroupEmails(@RequestBody List<@Valid RsvpGroup> rsvpGroups) {
+        rsvpGroupService.updateRsvpGroupEmails(rsvpGroups);
+    }
+
+    /**
+     * Updates rsvp groups by their id. Updates rsvps by their id. Will only update the email value in the rsvp groups.
+     * Will only update the attending status and food restrictions in the rsvps.
+     * @param rsvpGroups List of JSON objects that represents rsvp groups.
+     */
+    @PostMapping("/update-rsvp-and-rsvp-groups")
+    public void updateRsvpAndRsvpGroups(@RequestBody List<@Valid RsvpGroup> rsvpGroups) {
+        rsvpGroupService.updateRsvpGroupEmails(rsvpGroups);
+
+        List<Rsvp> rsvps = new ArrayList<>();
+        for (RsvpGroup rsvpGroup : rsvpGroups) {
+            rsvps.addAll(rsvpGroup.getRsvps());
+        }
+        rsvpService.updateRsvpAttendingAndFoodRestrictions(rsvps);
     }
 }

--- a/src/main/java/com/dillon/weddingrsvpapi/dto/DietaryRestriction.java
+++ b/src/main/java/com/dillon/weddingrsvpapi/dto/DietaryRestriction.java
@@ -38,5 +38,5 @@ public enum DietaryRestriction {
     /**
      * Dietary restriction for not being able to consume dairy products.
      */
-    DAIRY
+    NO_DAIRY
 }

--- a/src/main/java/com/dillon/weddingrsvpapi/dto/DietaryRestriction.java
+++ b/src/main/java/com/dillon/weddingrsvpapi/dto/DietaryRestriction.java
@@ -33,5 +33,10 @@ public enum DietaryRestriction {
     /**
      * Dietary restriction for not being able to consume anything not specified in this enumeration.
      */
-    OTHER
+    OTHER,
+
+    /**
+     * Dietary restriction for not being able to consume dairy products.
+     */
+    DAIRY
 }

--- a/src/main/java/com/dillon/weddingrsvpapi/dto/Rsvp.java
+++ b/src/main/java/com/dillon/weddingrsvpapi/dto/Rsvp.java
@@ -5,6 +5,9 @@ import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * A rsvp represents data pertaining to a single wedding guest.
  */
@@ -42,4 +45,20 @@ public class Rsvp {
      * Denotes if the guest is attending the wedding or not.
      */
     private Boolean attending;
+
+    /**
+     * The dietary restrictions belonging to the rsvp.
+     */
+    @Enumerated(EnumType.STRING)
+    @OrderColumn(name = "dietary_restrictions")
+    @Builder.Default
+    private List<DietaryRestriction> dietaryRestrictions = new ArrayList<>();
+
+    /**
+     * the food allergies belonging to the rsvp.
+     */
+    @Enumerated(EnumType.STRING)
+    @Column(name = "food_allergies")
+    @Builder.Default
+    private List<FoodAllergies> foodAllergies = new ArrayList<>();
 }

--- a/src/main/java/com/dillon/weddingrsvpapi/dto/RsvpGroup.java
+++ b/src/main/java/com/dillon/weddingrsvpapi/dto/RsvpGroup.java
@@ -44,22 +44,6 @@ public class RsvpGroup {
     private Set<Rsvp> rsvps = new HashSet<>();
 
     /**
-     * The dietary restrictions belonging to the rsvp group.
-     */
-    @Enumerated(EnumType.STRING)
-    @OrderColumn(name = "dietary_restrictions")
-    @Builder.Default
-    private List<DietaryRestriction> dietaryRestrictions = new ArrayList<>();
-
-    /**
-     * the food allergies belonging to the rsvp group.
-     */
-    @Enumerated(EnumType.STRING)
-    @Column(name = "food_allergies")
-    @Builder.Default
-    private List<FoodAllergies> foodAllergies = new ArrayList<>();
-
-    /**
      * The email belonging to the rsvp group.
      */
     private String email;

--- a/src/main/java/com/dillon/weddingrsvpapi/service/RsvpGroupService.java
+++ b/src/main/java/com/dillon/weddingrsvpapi/service/RsvpGroupService.java
@@ -74,12 +74,10 @@ public class RsvpGroupService {
         Map<Long, RsvpGroup> existingRsvpGroupsMap = existingRsvpGroups.stream()
                 .collect(Collectors.toMap(RsvpGroup::getId, Function.identity()));
 
-        // Update the rsvp groups that exist using what was provided from the request. Matching by id.
+        // Update the rsvp groups that exist using what was provided from the request. Matching by id. Only update email.
         for(RsvpGroup r : rsvpGroupFromRequest) {
             if(existingRsvpGroupsMap.containsKey(r.getId())) {
                 RsvpGroup rsvpGroup = existingRsvpGroupsMap.get(r.getId());
-                rsvpGroup.setDietaryRestrictions(r.getDietaryRestrictions());
-                rsvpGroup.setFoodAllergies(r.getFoodAllergies());
                 rsvpGroup.setEmail(r.getEmail());
                 existingRsvpGroupsMap.put(r.getId(), rsvpGroup); // replace what was queried with what was sent from request
             } else {

--- a/src/main/java/com/dillon/weddingrsvpapi/service/RsvpGroupService.java
+++ b/src/main/java/com/dillon/weddingrsvpapi/service/RsvpGroupService.java
@@ -65,7 +65,7 @@ public class RsvpGroupService {
      * @param rsvpGroupFromRequest Rsvps groups to update.
      */
     @Transactional
-    public void updateRsvpGroups(List<RsvpGroup> rsvpGroupFromRequest) {
+    public void updateRsvpGroupEmails(List<RsvpGroup> rsvpGroupFromRequest) {
 
         // Find rsvp groups that exist with the list provided in the request.
         List<RsvpGroup> existingRsvpGroups = rsvpGroupRepository.findAllById(rsvpGroupFromRequest.stream().map(RsvpGroup::getId).collect(Collectors.toList()));

--- a/src/main/java/com/dillon/weddingrsvpapi/service/RsvpService.java
+++ b/src/main/java/com/dillon/weddingrsvpapi/service/RsvpService.java
@@ -50,7 +50,7 @@ public class RsvpService {
      * @param rsvpsFromRequest Rsvps to update.
      */
     @Transactional
-    public void updateRsvpsAttending(List<Rsvp> rsvpsFromRequest) {
+    public void updateRsvpAttendingAndFoodRestrictions(List<Rsvp> rsvpsFromRequest) {
 
         // Find rsvps that exist with the list provided in the request.
         List<Long> idsFromRequest = rsvpsFromRequest.stream().map(Rsvp::getId).toList();

--- a/src/main/java/com/dillon/weddingrsvpapi/service/RsvpService.java
+++ b/src/main/java/com/dillon/weddingrsvpapi/service/RsvpService.java
@@ -60,12 +60,15 @@ public class RsvpService {
         Map<Long, Rsvp> existingRsvpsMap = existingRsvps.stream()
                 .collect(Collectors.toMap(Rsvp::getId, Function.identity()));
 
-        // Update the rsvps that exist using what was provided from the request. Matching by id.
+        // Update the rsvps that exist using what was provided from the request. Matching by id. Only update attending
+        // status, dietary restrictions, and food allergies.
         for(Rsvp r : rsvpsFromRequest) {
             if(existingRsvpsMap.containsKey(r.getId())) {
                 Rsvp rsvp = existingRsvpsMap.get(r.getId());
                 rsvp.setAttending(r.getAttending());
-                existingRsvpsMap.put(r.getId(), rsvp); // replace what was queried with what was sent from request
+                rsvp.setFoodAllergies(r.getFoodAllergies());
+                rsvp.setDietaryRestrictions(r.getDietaryRestrictions());
+                existingRsvpsMap.put(r.getId(), rsvp); // Replace what was queried with what was sent from request.
             } else {
                 // If request had any ids not in database throw exception.
                 throw new RsvpNotFoundException(r.getId());

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -2,13 +2,13 @@ DELETE FROM rsvp;
 DELETE FROM rsvp_group;
 
 -- group one
-INSERT INTO rsvp_group (dietary_restrictions, food_allergies, email, group_lead) VALUES (ARRAY['NO_PORK'], ARRAY['DAIRY'], 'test1@test.com', 'John Smith');
-INSERT INTO rsvp (name, attending, group_id) VALUES ('John Smith', false, (SELECT id FROM rsvp_group WHERE group_lead = 'John Smith'));
-INSERT INTO rsvp (name, attending, group_id) VALUES ('Jane Doe', true, (SELECT id FROM rsvp_group WHERE group_lead = 'John Smith'));
+INSERT INTO rsvp_group (email, group_lead) VALUES ('test1@test.com', 'John Smith');
+INSERT INTO rsvp (dietary_restrictions, food_allergies, name, attending, group_id) VALUES (ARRAY['NO_PORK'], ARRAY['DAIRY'], 'John Smith', false, (SELECT id FROM rsvp_group WHERE group_lead = 'John Smith'));
+INSERT INTO rsvp (dietary_restrictions, food_allergies, name, attending, group_id) VALUES (ARRAY['NO_PORK'], ARRAY['DAIRY'], 'Jane Doe', false, (SELECT id FROM rsvp_group WHERE group_lead = 'John Smith'));
 
 -- group two
-INSERT INTO rsvp_group (dietary_restrictions, food_allergies, email, group_lead) VALUES (ARRAY['NO_RED_MEAT', 'NO_CHICKEN'], ARRAY['PEANUTS'], 'test2@test.com', 'Homer Simpson');
-INSERT INTO rsvp (name, attending, group_id) VALUES ('Homer Simpson', true, (SELECT id FROM rsvp_group WHERE group_lead = 'Homer Simpson'));
-INSERT INTO rsvp (name, attending, group_id) VALUES ('Marge Simpson', true, (SELECT id FROM rsvp_group WHERE group_lead = 'Homer Simpson'));
-INSERT INTO rsvp (name, attending, group_id) VALUES ('Lisa Simpson', false, (SELECT id FROM rsvp_group WHERE group_lead = 'Homer Simpson'));
-INSERT INTO rsvp (name, attending, group_id) VALUES ('Bart Simpson', false, (SELECT id FROM rsvp_group WHERE group_lead = 'Homer Simpson'));
+INSERT INTO rsvp_group (email, group_lead) VALUES ('test2@test.com', 'Homer Simpson');
+INSERT INTO rsvp (dietary_restrictions, food_allergies, name, attending, group_id) VALUES (ARRAY['NO_RED_MEAT', 'NO_CHICKEN'], ARRAY['PEANUTS'], 'Homer Simpson', true, (SELECT id FROM rsvp_group WHERE group_lead = 'Homer Simpson'));
+INSERT INTO rsvp (dietary_restrictions, food_allergies, name, attending, group_id) VALUES (ARRAY['NO_RED_MEAT', 'NO_CHICKEN'], ARRAY['PEANUTS'], 'Marge Simpson', true, (SELECT id FROM rsvp_group WHERE group_lead = 'Homer Simpson'));
+INSERT INTO rsvp (dietary_restrictions, food_allergies, name, attending, group_id) VALUES (ARRAY['NO_RED_MEAT', 'NO_CHICKEN'], ARRAY['PEANUTS'], 'Lisa Simpson', false, (SELECT id FROM rsvp_group WHERE group_lead = 'Homer Simpson'));
+INSERT INTO rsvp (dietary_restrictions, food_allergies, name, attending, group_id) VALUES (ARRAY['NO_RED_MEAT', 'NO_CHICKEN'], ARRAY['PEANUTS'], 'Bart Simpson', false, (SELECT id FROM rsvp_group WHERE group_lead = 'Homer Simpson'));

--- a/src/main/resources/db/changelog/sql/00020-dietRestrictionRsvp.sql
+++ b/src/main/resources/db/changelog/sql/00020-dietRestrictionRsvp.sql
@@ -1,0 +1,12 @@
+--liquibase formatted sql
+--changeset dillon:00020-dietRestrictionRsvp
+
+
+-- Move columns from rsvp_group that are more appropriate to be referenced on a rsvp level.
+ALTER TABLE rsvp_group DROP COLUMN dietary_restrictions;
+
+ALTER TABLE rsvp_group DROP COLUMN food_allergies;
+
+ALTER TABLE rsvp ADD COLUMN dietary_restrictions VARCHAR(28) ARRAY;
+
+ALTER TABLE rsvp ADD COLUMN food_allergies VARCHAR(28) ARRAY;

--- a/src/test/groovy/com/dillon/weddingrsvpapi/controller/RsvpControllerSpec.groovy
+++ b/src/test/groovy/com/dillon/weddingrsvpapi/controller/RsvpControllerSpec.groovy
@@ -2,6 +2,8 @@ package com.dillon.weddingrsvpapi.controller
 
 import com.dillon.weddingrsvpapi.db.RsvpGroupRepository
 import com.dillon.weddingrsvpapi.db.RsvpRepository
+import com.dillon.weddingrsvpapi.dto.DietaryRestriction
+import com.dillon.weddingrsvpapi.dto.FoodAllergies
 import com.dillon.weddingrsvpapi.dto.RsvpGroup
 import com.dillon.weddingrsvpapi.util.ApiError
 import com.dillon.weddingrsvpapi.dto.Rsvp
@@ -57,17 +59,21 @@ class RsvpControllerSpec extends Specification {
         setup:
         def rsvpOne = Rsvp.builder()
             .attending(false)
+            .dietaryRestrictions(List.of( DietaryRestriction.NO_PORK ))
+            .foodAllergies(List.of( FoodAllergies.DAIRY ))
             .name("John Smith").build()
         def rsvpOneSaved = rsvpRepository.save(rsvpOne)
 
         def rsvpTwo = Rsvp.builder()
             .attending(false)
+            .dietaryRestrictions(List.of( DietaryRestriction.NO_PORK ))
+            .foodAllergies(List.of( FoodAllergies.DAIRY ))
             .name("Jane Doe").build()
         def rsvpTwoSaved = rsvpRepository.save(rsvpTwo)
 
         def rsvpList = [
-            ["id": 1, "attending": true],
-            ["id": 2, "attending": true]
+            ["id": 1, "attending": true, "dietaryRestrictions": ["NO_FISH"], "foodAllergies": ["FISH"]],
+            ["id": 2, "attending": true, "dietaryRestrictions": ["NO_FISH"], "foodAllergies": ["FISH"]]
         ]
 
         when:
@@ -81,7 +87,11 @@ class RsvpControllerSpec extends Specification {
         then:
         result.statusCode == HttpStatus.OK
         retRsvpOne.get().attending == true
+        retRsvpOne.get().dietaryRestrictions == [DietaryRestriction.NO_FISH]
+        retRsvpOne.get().foodAllergies == [FoodAllergies.FISH]
         retRsvpTwo.get().attending == true
+        retRsvpTwo.get().dietaryRestrictions == [DietaryRestriction.NO_FISH]
+        retRsvpTwo.get().foodAllergies == [FoodAllergies.FISH]
     }
 
     def 'When an rsvp that is not saved is updated, it returns HttpStatus.NOT_FOUND'() {

--- a/src/test/groovy/com/dillon/weddingrsvpapi/controller/RsvpControllerSpec.groovy
+++ b/src/test/groovy/com/dillon/weddingrsvpapi/controller/RsvpControllerSpec.groovy
@@ -4,7 +4,6 @@ import com.dillon.weddingrsvpapi.db.RsvpGroupRepository
 import com.dillon.weddingrsvpapi.db.RsvpRepository
 import com.dillon.weddingrsvpapi.dto.DietaryRestriction
 import com.dillon.weddingrsvpapi.dto.FoodAllergies
-import com.dillon.weddingrsvpapi.dto.RsvpGroup
 import com.dillon.weddingrsvpapi.util.ApiError
 import com.dillon.weddingrsvpapi.dto.Rsvp
 import com.fasterxml.jackson.databind.ObjectMapper
@@ -12,15 +11,12 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.web.client.TestRestTemplate
 import org.springframework.boot.test.web.server.LocalServerPort
-import org.springframework.core.io.ClassPathResource
 import org.springframework.http.client.ClientHttpRequestInterceptor
-import org.springframework.jdbc.datasource.init.ScriptUtils
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.http.HttpStatus
 
 import spock.lang.Specification
 
-import java.sql.Connection
 
 @ActiveProfiles("test")
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)

--- a/src/test/groovy/com/dillon/weddingrsvpapi/controller/RsvpGroupControllerSpec.groovy
+++ b/src/test/groovy/com/dillon/weddingrsvpapi/controller/RsvpGroupControllerSpec.groovy
@@ -122,8 +122,8 @@ class RsvpGroupControllerSpec extends Specification {
             it.status == HttpStatus.BAD_REQUEST
             it.message == "Request was invalid"
             it.errors == [
-                "updateRsvpGroups.rsvpGroups[0].id": "Id is mandatory.",
-                "updateRsvpGroups.rsvpGroups[1].id": "Id is mandatory."
+                "updateRsvpGroupEmails.rsvpGroups[0].id": "Id is mandatory.",
+                "updateRsvpGroupEmails.rsvpGroups[1].id": "Id is mandatory."
             ]
         }
     }

--- a/src/test/groovy/com/dillon/weddingrsvpapi/db/RsvpGroupRepositorySpec.groovy
+++ b/src/test/groovy/com/dillon/weddingrsvpapi/db/RsvpGroupRepositorySpec.groovy
@@ -80,16 +80,23 @@ class RsvpGroupRepositorySpec extends Specification {
         !rsvpGroupRet[0].modifyGroup
         rsvpGroupRet[0].groupLead == "John Smith"
         rsvpGroupRet[0].rsvps.size() == 2
+        rsvpGroupRet[0].rsvps.any{it.name == "John Smith"}
+        rsvpGroupRet[0].rsvps.any{it.name == "Jane Doe"}
+        Rsvp[] rsvpsArray = rsvpGroupRet[0].rsvps.toArray(new Rsvp[rsvpGroupRet[0].rsvps.size()])
 
-        !rsvpGroupRet[0].rsvps[0].attending
-        rsvpGroupRet[0].rsvps[0].name == "John Smith"
-        rsvpGroupRet[0].rsvps[0].id == 1
-        rsvpGroupRet[0].rsvps[0].dietaryRestrictions == [DietaryRestriction.NO_PORK]
-        rsvpGroupRet[0].rsvps[0].foodAllergies == [FoodAllergies.DAIRY]
-        !rsvpGroupRet[0].rsvps[1].attending
-        rsvpGroupRet[0].rsvps[1].name == "Jane Doe"
-        rsvpGroupRet[0].rsvps[1].id == 2
-        rsvpGroupRet[0].rsvps[1].dietaryRestrictions == [DietaryRestriction.NO_PORK]
-        rsvpGroupRet[0].rsvps[1].foodAllergies == [FoodAllergies.DAIRY]
+        for (Rsvp r : rsvpsArray) {
+            if (r.name == "John Smith") {
+                r.attending
+                r.id == 1
+                r.dietaryRestrictions == [DietaryRestriction.NO_PORK]
+                r.foodAllergies == [FoodAllergies.DAIRY]
+            }
+            if (r.name == "Jane Doe") {
+                !r.attending
+                r.id == 2
+                r.dietaryRestrictions == [DietaryRestriction.NO_PORK]
+                r.foodAllergies == [FoodAllergies.DAIRY]
+            }
+        }
     }
 }

--- a/src/test/groovy/com/dillon/weddingrsvpapi/db/RsvpGroupRepositorySpec.groovy
+++ b/src/test/groovy/com/dillon/weddingrsvpapi/db/RsvpGroupRepositorySpec.groovy
@@ -26,19 +26,21 @@ class RsvpGroupRepositorySpec extends Specification {
         // expected group and members to return
         def rsvp = Rsvp.builder()
             .id(1)
+            .dietaryRestrictions(List.of( DietaryRestriction.NO_PORK ))
+            .foodAllergies(List.of( FoodAllergies.DAIRY ))
             .attending(false)
             .name("John Smith").build()
         rsvpRepository.save(rsvp)
         def rsvpTwo = Rsvp.builder()
             .id(2)
+            .dietaryRestrictions(List.of( DietaryRestriction.NO_PORK ))
+            .foodAllergies(List.of( FoodAllergies.DAIRY ))
             .attending(false)
             .name("Jane Doe").build()
         rsvpRepository.save(rsvpTwo)
 
         def rsvpGroup = RsvpGroup.builder()
             .id(1)
-            .dietaryRestrictions(List.of( DietaryRestriction.NO_PORK ))
-            .foodAllergies(List.of( FoodAllergies.DAIRY ))
             .email("test@test.com")
             .modifyGroup(false)
             .rsvps(Set.of(rsvp, rsvpTwo))
@@ -48,19 +50,21 @@ class RsvpGroupRepositorySpec extends Specification {
         // group of members whose nobody's name is similar to the provided name
         def rsvpThree = Rsvp.builder()
             .id(3)
+            .dietaryRestrictions(List.of( DietaryRestriction.NO_PORK ))
+            .foodAllergies(List.of( FoodAllergies.DAIRY ))
             .attending(false)
             .name("Micheal James").build()
         rsvpRepository.save(rsvpThree)
         def rsvpFour = Rsvp.builder()
             .id(4)
+            .dietaryRestrictions(List.of( DietaryRestriction.NO_PORK ))
+            .foodAllergies(List.of( FoodAllergies.DAIRY ))
             .attending(false)
             .name("Gracie James").build()
         rsvpRepository.save(rsvpFour)
 
         def rsvpGroupTwo = RsvpGroup.builder()
             .id(2)
-            .dietaryRestrictions(List.of( DietaryRestriction.NO_PORK ))
-            .foodAllergies(List.of( FoodAllergies.DAIRY ))
             .email("test@test.com")
             .modifyGroup(false)
             .rsvps(Set.of(rsvpThree, rsvpFour))
@@ -72,8 +76,6 @@ class RsvpGroupRepositorySpec extends Specification {
 
         then:
         rsvpGroupRet.size() == 1
-        rsvpGroupRet[0].dietaryRestrictions == [DietaryRestriction.NO_PORK]
-        rsvpGroupRet[0].foodAllergies == [FoodAllergies.DAIRY]
         rsvpGroupRet[0].email == "test@test.com"
         !rsvpGroupRet[0].modifyGroup
         rsvpGroupRet[0].groupLead == "John Smith"
@@ -82,8 +84,12 @@ class RsvpGroupRepositorySpec extends Specification {
         !rsvpGroupRet[0].rsvps[0].attending
         rsvpGroupRet[0].rsvps[0].name == "John Smith"
         rsvpGroupRet[0].rsvps[0].id == 1
+        rsvpGroupRet[0].rsvps[0].dietaryRestrictions == [DietaryRestriction.NO_PORK]
+        rsvpGroupRet[0].rsvps[0].foodAllergies == [FoodAllergies.DAIRY]
         !rsvpGroupRet[0].rsvps[1].attending
         rsvpGroupRet[0].rsvps[1].name == "Jane Doe"
         rsvpGroupRet[0].rsvps[1].id == 2
+        rsvpGroupRet[0].rsvps[1].dietaryRestrictions == [DietaryRestriction.NO_PORK]
+        rsvpGroupRet[0].rsvps[1].foodAllergies == [FoodAllergies.DAIRY]
     }
 }

--- a/src/test/groovy/com/dillon/weddingrsvpapi/dto/RsvpGroupSpec.groovy
+++ b/src/test/groovy/com/dillon/weddingrsvpapi/dto/RsvpGroupSpec.groovy
@@ -15,14 +15,14 @@ class RsvpGroupSpec extends Specification {
         setup:
         def rsvp = Rsvp.builder()
             .id(1)
+            .dietaryRestrictions(List.of( DietaryRestriction.NO_PORK ))
+            .foodAllergies(List.of( FoodAllergies.DAIRY ))
             .attending(false)
             .name("John Smith").build()
 
         def rsvpGroup = RsvpGroup.builder()
             .id(1)
             .rsvps(Set.of(rsvp))
-            .dietaryRestrictions(List.of( DietaryRestriction.NO_PORK ))
-            .foodAllergies(List.of( FoodAllergies.DAIRY ))
             .email("test@test.com")
             .modifyGroup(true)
             .groupLead("John Smith").build()
@@ -31,8 +31,6 @@ class RsvpGroupSpec extends Specification {
         rsvpGroup.id == 1
         rsvpGroup.rsvps == Set.of(rsvp)
         rsvpGroup.modifyGroup
-        rsvpGroup.dietaryRestrictions == List.of( DietaryRestriction.NO_PORK )
-        rsvpGroup.foodAllergies == List.of( FoodAllergies.DAIRY )
         rsvpGroup.email == "test@test.com"
         rsvpGroup.groupLead == "John Smith"
     }
@@ -41,14 +39,14 @@ class RsvpGroupSpec extends Specification {
         setup:
         def rsvp = Rsvp.builder()
             .id(1)
+            .dietaryRestrictions(List.of( DietaryRestriction.NO_PORK ))
+            .foodAllergies(List.of( FoodAllergies.DAIRY ))
             .attending(false)
             .name("John Smith").build()
 
         def rsvpGroup = RsvpGroup.builder()
             .id(1)
             .rsvps(Set.of(rsvp))
-            .dietaryRestrictions(List.of( DietaryRestriction.NO_PORK ))
-            .foodAllergies(List.of( FoodAllergies.DAIRY ))
             .email("test@test.com")
             .modifyGroup(true)
             .groupLead("John Smith").build()

--- a/src/test/groovy/com/dillon/weddingrsvpapi/dto/RsvpSpec.groovy
+++ b/src/test/groovy/com/dillon/weddingrsvpapi/dto/RsvpSpec.groovy
@@ -15,14 +15,14 @@ class RsvpSpec extends Specification {
         setup:
         def rsvpGroup = RsvpGroup.builder()
             .id(1)
-            .dietaryRestrictions(List.of( DietaryRestriction.NO_PORK ))
-            .foodAllergies(List.of( FoodAllergies.DAIRY ))
             .email("test@test.com")
             .modifyGroup(true)
             .groupLead("John Smith").build()
 
         def rsvp = Rsvp.builder()
             .id(1)
+            .dietaryRestrictions(List.of( DietaryRestriction.NO_PORK ))
+            .foodAllergies(List.of( FoodAllergies.DAIRY ))
             .rsvpGroup(rsvpGroup)
             .attending(false)
             .name("John Smith").build()
@@ -38,14 +38,14 @@ class RsvpSpec extends Specification {
         setup:
         def rsvpGroup = RsvpGroup.builder()
             .id(1)
-            .dietaryRestrictions(List.of( DietaryRestriction.NO_PORK ))
-            .foodAllergies(List.of( FoodAllergies.DAIRY ))
             .email("test@test.com")
             .modifyGroup(true)
             .groupLead("John Smith").build()
 
         def rsvp = Rsvp.builder()
             .id(1)
+            .dietaryRestrictions(List.of( DietaryRestriction.NO_PORK ))
+            .foodAllergies(List.of( FoodAllergies.DAIRY ))
             .rsvpGroup(rsvpGroup)
             .attending(false)
             .name("John Smith").build()

--- a/src/test/groovy/com/dillon/weddingrsvpapi/service/RsvpGroupServiceSpec.groovy
+++ b/src/test/groovy/com/dillon/weddingrsvpapi/service/RsvpGroupServiceSpec.groovy
@@ -42,8 +42,8 @@ class RsvpGroupServiceSpec extends Specification {
         notThrown(RsvpGroupNotFoundException)
     }
 
-    // Test updateRsvpGroups()
-    def 'When a valid rsvp group does not exists and is updated, updateRsvpGroups throws RsvpGroupNotFoundException'() {
+    // Test updateRsvpGroupEmails()
+    def 'When a valid rsvp group does not exists and is updated, updateRsvpGroupEmails throws RsvpGroupNotFoundException'() {
         setup:
         RsvpGroup rsvpGroupOne = Mock()
         rsvpGroupOne.getId() >> 1
@@ -51,7 +51,7 @@ class RsvpGroupServiceSpec extends Specification {
         rsvpGroupRepository.findAllById([1]) >> []
 
         when:
-        rsvpGroupService.updateRsvpGroups([rsvpGroupOne])
+        rsvpGroupService.updateRsvpGroupEmails([rsvpGroupOne])
 
         then:
         thrown RsvpGroupNotFoundException
@@ -65,7 +65,7 @@ class RsvpGroupServiceSpec extends Specification {
         rsvpGroupRepository.findAllById([1]) >> [new RsvpGroup(id:  1)]
 
         when:
-        rsvpGroupService.updateRsvpGroups([rsvpGroupOne])
+        rsvpGroupService.updateRsvpGroupEmails([rsvpGroupOne])
 
         then:
         notThrown RsvpGroupNotFoundException

--- a/src/test/groovy/com/dillon/weddingrsvpapi/service/RsvpServiceSpec.groovy
+++ b/src/test/groovy/com/dillon/weddingrsvpapi/service/RsvpServiceSpec.groovy
@@ -42,8 +42,8 @@ class RsvpServiceSpec extends Specification {
         notThrown(RsvpNotFoundException)
     }
 
-    // Test updateRsvpsAttending()
-    def 'When a valid rsvp does not exists and is updated, updateRsvpsAttending throws RsvpNotFoundException'() {
+    // Test updateRsvpAttendingAndFoodRestrictions()
+    def 'When a valid rsvp does not exists and is updated, updateRsvpAttendingAndFoodRestrictions throws RsvpNotFoundException'() {
         setup:
         Rsvp rsvpOne = Mock()
         rsvpOne.getId() >> 1
@@ -51,7 +51,7 @@ class RsvpServiceSpec extends Specification {
         rsvpRepository.findAllById([1]) >> []
 
         when:
-        rsvpService.updateRsvpsAttending([rsvpOne])
+        rsvpService.updateRsvpAttendingAndFoodRestrictions([rsvpOne])
 
         then:
         thrown RsvpNotFoundException
@@ -65,7 +65,7 @@ class RsvpServiceSpec extends Specification {
         rsvpRepository.findAllById([1]) >> [new Rsvp(id:  1)]
 
         when:
-        rsvpService.updateRsvpsAttending([rsvpOne])
+        rsvpService.updateRsvpAttendingAndFoodRestrictions([rsvpOne])
 
         then:
         notThrown RsvpNotFoundException


### PR DESCRIPTION
This moves the food restrictions from the rsvp_group to rsvp table. This also updates tests and adds a new endpoint to simultaneously update rsvp_group and rsvp records.